### PR TITLE
✨ feat(36): Add zoxide and atuin CLI tools

### DIFF
--- a/home-manager/cli/alternative.nix
+++ b/home-manager/cli/alternative.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+
+{
+  # Add alternative CLI tools like zoxide and atuin
+
+  # Fast directory navigation
+  programs.zoxide = {
+    enable = true;
+    # Optional: Add aliases or other zoxide settings if needed
+    # enableZshIntegration = true; # Assuming zsh is used, adjust if needed
+  };
+
+  # Enhanced shell history search
+  programs.atuin = {
+    enable = true;
+    # Optional: Configure atuin settings if needed
+    # settings = {
+    #   auto_sync = true;
+    # };
+  };
+}

--- a/home-manager/cli/default.nix
+++ b/home-manager/cli/default.nix
@@ -9,5 +9,6 @@
     ./terminal/starship.nix
     ./terminal/zellij.nix
     ./terminal/foot.nix
+    ./alternative.nix
   ];
 }


### PR DESCRIPTION
Implements additions suggested in #36.

- Adds `zoxide` for faster directory navigation.
- Adds `atuin` for enhanced shell history search.
- Creates a new `home-manager/cli/alternative.nix` module to house these tools.

Closes #36