### PR TITLE
✨ Add opaque rules for firefox/zen and enable firefox

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -909,7 +909,8 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
         "rust-overlay": "rust-overlay",
-        "xremap": "xremap"
+        "xremap": "xremap",
+        "zen-browser-flake": "zen-browser-flake"
       }
     },
     "rust-overlay": {
@@ -1152,6 +1153,26 @@
         "owner": "k0kubun",
         "ref": "v0.10.7",
         "repo": "xremap",
+        "type": "github"
+      }
+    },
+    "zen-browser-flake": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1727721329,
+        "narHash": "sha256-QYlWZwUSwrM7BuO+dXclZIwoPvBIuJr6GpFKv9XKFPI=",
+        "owner": "MarceColl",
+        "repo": "zen-browser-flake",
+        "rev": "e6ab73f405e9a2896cce5956c549a9cc359e5fcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "MarceColl",
+        "repo": "zen-browser-flake",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,10 @@
       url = "github:natsukium/mcp-servers-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    zen-browser-flake = {
+      url = "github:MarceColl/zen-browser-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     /*
       hyprland = {
       url = "github:hyprwm/Hyprland/v0.48.0";
@@ -56,7 +60,7 @@
 
   # System Configuration
   # Main outputs section defining system configurations, overlays, and home-manager setups
-  outputs = { self, nixpkgs, home-manager, rust-overlay, nixos-hardware, xremap, flake-utils, claude-desktop, mcp-servers-nix, ... }@inputs:
+  outputs = { self, nixpkgs, home-manager, rust-overlay, nixos-hardware, xremap, flake-utils, claude-desktop, mcp-servers-nix, zen-browser-flake, ... }@inputs:
     let
       # Python builder utilities
       mkPythonBuilders = pkgs: {
@@ -191,6 +195,9 @@
 
           # Add Python-related functionality
           inherit (mkPythonBuilders prev) buildPython pythonVersions;
+
+          # Add zen-browser overlay
+          zen-browser = zen-browser-flake.packages.${prev.system}.default or zen-browser-flake.packages.${prev.system}.zen-browser; # Try both default and zen-browser names
         };
       };
 

--- a/home-manager/gui/browser/browser.nix
+++ b/home-manager/gui/browser/browser.nix
@@ -7,6 +7,7 @@
     brave.enable = true;
     # Use Home Manager's intended option for command line args
     brave.commandLineArgs = [ "--enable-features=UseOzonePlatform" "--ozone-platform=x11" ];
+    firefox.enable = true;
   };
 
   # Removed ineffective brave-flags.conf definition

--- a/home-manager/gui/browser/browser.nix
+++ b/home-manager/gui/browser/browser.nix
@@ -10,6 +10,9 @@
     firefox.enable = true;
   };
 
+  # Add zen-browser package
+  home.packages = [ pkgs.zen-browser ];
+
   # Removed ineffective brave-flags.conf definition
   # xdg.configFile."brave-flags.conf".text = ''
   #  ...

--- a/home-manager/wm/hyprland/default.nix
+++ b/home-manager/wm/hyprland/default.nix
@@ -129,6 +129,18 @@
         "float,class:^()$,title:^(Playwright Inspector)$"
 
         # rulev2 for foot
+        "opaque, class:(code)"
+        "opaque, class:(Code)"
+        "opaque, class:(thunar)"
+        "opaque, class:(Thunar)"
+        "opaque, class:(pavucontrol)"
+        "opaque, class:(Pavucontrol)"
+        "opaque, class:(org.gnome.Nautilus)"
+        "opaque, class:(nemo)"
+        "opaque, class:(Nemo)"
+        "opaque, class:(zen)"
+        "opaque, class:(firefox)"
+        "opaque, class:(Firefox)"
         "opacity 0.9 0.9, class:^(foot-quick)$"
         "float, class:^(foot-quick)$"
         "size 98% 40%, class:^(foot-quick)$"


### PR DESCRIPTION
Adds Hyprland window rules to make firefox and zen opaque based on Issue #29. Also enables the firefox package in Home Manager configuration. Closes #29